### PR TITLE
feat: various small style fixes

### DIFF
--- a/.changeset/brown-vans-repair.md
+++ b/.changeset/brown-vans-repair.md
@@ -6,6 +6,6 @@
 - Added 'padding' prop to popover (default: 'md')
 - Set padding between pane title and tabs to '$6' (was '$2')
 - Added options '2' and '3' to 'bg' prop for code component
-- Set copyButton to 'position: absolute' in top right corder of code 'pre'
-- Set copyButton to show on hover
-- Set copyButton to size 'sm' (was 'xs')
+- Set copyButton in code component to 'position: absolute' in top right corder of code 'pre'
+- Set copyButton in code component to show on hover
+- Set copyButton variant="icon" to size="md"

--- a/.changeset/brown-vans-repair.md
+++ b/.changeset/brown-vans-repair.md
@@ -1,0 +1,11 @@
+---
+'@darkmagic/react': minor
+---
+
+Set cursor style to 'pointer' for button, iconButton, select, and tabs
+Added 'padding' prop to popover (default: 'md')
+Set padding between pane title and tabs to '$6' (was '$2')
+Added options '2' and '3' to 'bg' prop for code component
+Set copyButton to 'position: absolute' in top right corder of code 'pre'
+Set copyButton to show on hover
+Set copyButton to size 'sm' (was 'xs')

--- a/.changeset/brown-vans-repair.md
+++ b/.changeset/brown-vans-repair.md
@@ -2,10 +2,10 @@
 '@darkmagic/react': minor
 ---
 
-Set cursor style to 'pointer' for button, iconButton, select, and tabs
-Added 'padding' prop to popover (default: 'md')
-Set padding between pane title and tabs to '$6' (was '$2')
-Added options '2' and '3' to 'bg' prop for code component
-Set copyButton to 'position: absolute' in top right corder of code 'pre'
-Set copyButton to show on hover
-Set copyButton to size 'sm' (was 'xs')
+- Set cursor style to 'pointer' for button, iconButton, select, and tabs
+- Added 'padding' prop to popover (default: 'md')
+- Set padding between pane title and tabs to '$6' (was '$2')
+- Added options '2' and '3' to 'bg' prop for code component
+- Set copyButton to 'position: absolute' in top right corder of code 'pre'
+- Set copyButton to show on hover
+- Set copyButton to size 'sm' (was 'xs')

--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -26,6 +26,7 @@ const StyledButton = styled('button', {
   borderRadius: '$base',
   fontWeight: '$normal',
   gap: '$2',
+  cursor: 'pointer',
 
   '&:focus': { outline: 'none' },
   // use a data attribute for compatibility with as="a"

--- a/packages/react/src/components/code.stories.tsx
+++ b/packages/react/src/components/code.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta = {
     lang: 'json',
     caption: 'JSON',
     lineClamp: 17,
+    bg: 1,
+  },
+  argTypes: {
+    bg: { control: 'select', options: [1, 2, 3] },
   },
 };
 

--- a/packages/react/src/components/code.tsx
+++ b/packages/react/src/components/code.tsx
@@ -60,6 +60,15 @@ const StyledExpandIcon = styled('span', {
   },
 });
 
+const StyledCopyButton = styled('div', {
+  position: 'absolute',
+  top: '$2',
+  right: '$2',
+  opacity: 0,
+  transition: 'all .18s ease-out',
+  zIndex: 1,
+});
+
 const StyledTitle = styled('div', {
   font: '$body-small-bold',
   color: '$text-muted',
@@ -179,11 +188,27 @@ const StyledPre = styled('pre', {
     content: 'attr(data-line-number)',
   },
 
+  // copy button
+
+  [`&:hover ${StyledCopyButton}`]: {
+    opacity: 1,
+  },
+
   variants: {
     bg: {
+      1: {
+        '& .hljs, & .hljs-ln td.hljs-ln-numbers': {
+          backgroundColor: '$bg-app',
+        },
+      },
       2: {
         '& .hljs, & .hljs-ln td.hljs-ln-numbers': {
           backgroundColor: '$bg-app-2',
+        },
+      },
+      3: {
+        '& .hljs, & .hljs-ln td.hljs-ln-numbers': {
+          backgroundColor: '$bg-default',
         },
       },
     },
@@ -329,14 +354,13 @@ export function Code({
     '& .hljs-ln-numbers': lineNumbers ? {} : { display: 'none' },
   };
 
-  const showHeader = caption || showCopyButton;
+  const showHeader = caption;
 
   return (
     <Box>
       {showHeader ? (
         <Flex justify="between">
           <StyledTitle>{caption}</StyledTitle>
-          {showCopyButton && <CopyButton value={String(highlighted.code)} />}
         </Flex>
       ) : null}
 
@@ -346,6 +370,11 @@ export function Code({
           <Box pt={showHeader ? 1 : 0} css={{ width }}>
             <ScrollArea direction={scroll}>
               <StyledPre tabIndex={0} css={css} bg={bg}>
+                {showCopyButton && (
+                  <StyledCopyButton>
+                    <CopyButton value={String(highlighted.code)} />
+                  </StyledCopyButton>
+                )}
                 <code className="hljs" dangerouslySetInnerHTML={{ __html: highlighted.value }} />
               </StyledPre>
             </ScrollArea>

--- a/packages/react/src/components/code.tsx
+++ b/packages/react/src/components/code.tsx
@@ -65,7 +65,7 @@ const StyledCopyButton = styled('div', {
   top: '$2',
   right: '$2',
   opacity: 0,
-  transition: 'all .18s ease-out',
+  transition: 'all .14s ease-out',
   zIndex: 1,
 });
 

--- a/packages/react/src/components/copy-button.tsx
+++ b/packages/react/src/components/copy-button.tsx
@@ -46,6 +46,6 @@ export function CopyButton({ value, onCopied, variant = 'icon' }: CopyButtonProp
       </Grid>
     </Button>
   ) : (
-    <IconButton css={css} onClick={handleClick} label="copy to clipboard" size="sm" variant="ghost" icon={icon} />
+    <IconButton css={css} onClick={handleClick} label="copy to clipboard" size="md" variant="ghost" icon={icon} />
   );
 }

--- a/packages/react/src/components/copy-button.tsx
+++ b/packages/react/src/components/copy-button.tsx
@@ -46,6 +46,6 @@ export function CopyButton({ value, onCopied, variant = 'icon' }: CopyButtonProp
       </Grid>
     </Button>
   ) : (
-    <IconButton css={css} onClick={handleClick} label="copy to clipboard" size="xs" variant="ghost" icon={icon} />
+    <IconButton css={css} onClick={handleClick} label="copy to clipboard" size="sm" variant="ghost" icon={icon} />
   );
 }

--- a/packages/react/src/components/icon-button.tsx
+++ b/packages/react/src/components/icon-button.tsx
@@ -25,6 +25,7 @@ const StyledButton = styled('button', {
 
   // Custom
   borderRadius: '$base',
+  cursor: 'pointer',
 
   '&:focus': { outline: 'none' },
   '&&:disabled': { opacity: 0.65, pointerEvents: 'none' },

--- a/packages/react/src/components/pane.tsx
+++ b/packages/react/src/components/pane.tsx
@@ -49,7 +49,7 @@ const StyledHeaderTabs = styled('div', {
   variants: {
     variant: {
       toolbar: { paddingTop: '$8' },
-      pane: { paddingTop: '$2' },
+      pane: { paddingTop: '$6' },
     },
     tabs: {
       contained: {},

--- a/packages/react/src/components/popover.stories.tsx
+++ b/packages/react/src/components/popover.stories.tsx
@@ -13,7 +13,7 @@ const Component: ComponentStoryFn<any> = (args) => (
     <Popover.Trigger>
       <IconButton label="Update sender" icon={MixerHorizontalIcon} />
     </Popover.Trigger>
-    <Popover.Content sideOffset={8} side={args.side}>
+    <Popover.Content sideOffset={8} side={args.side} padding={args.padding}>
       <Popover.Title>Update Sender</Popover.Title>
       <Popover.Body>
         <Flex css={{ flexDirection: 'column', gap: 10 }}>
@@ -34,8 +34,11 @@ const meta: Meta = {
   args: {
     open: true,
     content: 'Popover content',
+    padding: 'none',
   },
-  argTypes: {},
+  argTypes: {
+    padding: { control: 'select', options: ['none', 'sm', 'md', 'lg', 'xl'] },
+  },
   decorators: [
     (Story) => (
       <Flex align="center" justify="center" height="full">

--- a/packages/react/src/components/popover.tsx
+++ b/packages/react/src/components/popover.tsx
@@ -51,10 +51,17 @@ const StyledContent = styled(PopoverPrimitive.Content, {
 
   variants: {
     width: {
-      xs: { width: '$2xs' },
-      sm: { width: '$xs' },
-      md: { width: '$sm' },
-      lg: { width: '$lg' },
+      xs: { width: '$2xs', borderRadius: '$sm' },
+      sm: { width: '$xs', borderRadius: '$md' },
+      md: { width: '$sm', borderRadius: '$md' },
+      lg: { width: '$lg', borderRadius: '$lg' },
+    },
+    padding: {
+      none: { padding: '0' },
+      sm: { padding: '$sm' },
+      md: { padding: '$md' },
+      lg: { padding: '$lg' },
+      xl: { padding: '$xl' },
     },
   },
 });
@@ -93,6 +100,10 @@ type ContentProps = {
    * The width of the popover. Defaults to `md`.
    */
   width?: StyledContentProps['width'];
+  /**
+   * The padding of the popover. Defaults to `md`.
+   */
+  padding?: StyledContentProps['padding'];
   /**
    * Set to `false` to hide the close button.
    */
@@ -169,12 +180,12 @@ type ContentProps = {
 };
 
 const Content = forwardRef<ElementRef<typeof StyledContent>, ContentProps>(function Content(
-  { children, width = 'md', showCloseButton = true, ...props },
+  { children, width = 'md', padding = 'md', showCloseButton = true, ...props },
   ref,
 ) {
   return (
     <PopoverPrimitive.Portal>
-      <StyledContent width={width} {...props} ref={ref}>
+      <StyledContent width={width} padding={padding} {...props} ref={ref}>
         {children}
 
         {showCloseButton && (

--- a/packages/react/src/components/select.tsx
+++ b/packages/react/src/components/select.tsx
@@ -24,6 +24,7 @@ const StyledTrigger = styled(SelectPrimitive.SelectTrigger, {
   backgroundColor: '$bg-default',
   color: '$text-default',
   border: '1px solid transparent',
+  cursor: 'pointer',
 
   '&::before': { boxSizing: 'border-box' },
   '&::after': { boxSizing: 'border-box' },

--- a/packages/react/src/components/tabs.tsx
+++ b/packages/react/src/components/tabs.tsx
@@ -71,6 +71,7 @@ const StyledTrigger = styled(TabsPrimitive.Trigger, {
   display: 'inline-flex',
   alignItems: 'center',
   boxSizing: 'border-box',
+  cursor: 'pointer',
 
   userSelect: 'none',
   whiteSpace: 'nowrap',


### PR DESCRIPTION
### Improvements

- Set cursor style to 'pointer' for button, iconButton, select, and tabs

![Screen Shot 2023-03-29 at 5 13 22 PM](https://user-images.githubusercontent.com/106825828/228671430-68d3e327-1d93-4bcf-8f7f-d1e29b126c31.png)


- Added 'padding' prop to popover (default: 'md')

![Screen Shot 2023-03-29 at 5 15 01 PM](https://user-images.githubusercontent.com/106825828/228669511-30327e0b-82ed-40b8-84f3-d581e42928db.png)

- Added padding between pane title and tabs to '$6' (was '$2'). This aligns the padding between cards and panes

![Screen Shot 2023-03-29 at 5 12 04 PM](https://user-images.githubusercontent.com/106825828/228670352-b8241263-c0a9-4b46-8c4a-55e72043d221.png)

- Added options '2' and '3' to 'bg' prop for code component

![Screen Shot 2023-03-29 at 5 20 02 PM](https://user-images.githubusercontent.com/106825828/228670432-14604bd1-90b8-4fbf-87cd-9af91036d1b9.png)

- Set copyButton in code component to 'position: absolute' in top right corder of code 'pre'
- Set copyButton in code component to show on hover
- Set copyButton variant="icon" to size="md"

This eliminates the chunk of space required to render the copyButton when there is no caption (e.g. when code is in a card )

**Before**
![Screen Shot 2023-03-29 at 5 13 06 PM](https://user-images.githubusercontent.com/106825828/228670979-98ff6dd6-1b01-4970-8faa-d4b35bedc833.png)


**After**
![Screen Shot 2023-03-29 at 5 21 29 PM](https://user-images.githubusercontent.com/106825828/228670724-b0105d3d-7db6-4679-b46c-9253a5ecebfb.png)

