### PR TITLE
Fix drawer scrolling

### DIFF
--- a/.changeset/shaggy-eggs-cry.md
+++ b/.changeset/shaggy-eggs-cry.md
@@ -3,3 +3,4 @@
 ---
 
 Update style preview drawers from being scrollable
+Change default drawer background color to 'bg-app'

--- a/.changeset/shaggy-eggs-cry.md
+++ b/.changeset/shaggy-eggs-cry.md
@@ -1,0 +1,5 @@
+---
+'@darkmagic/react': minor
+---
+
+Update style preview drawers from being scrollable

--- a/packages/react/src/components/drawer.stories.tsx
+++ b/packages/react/src/components/drawer.stories.tsx
@@ -4,6 +4,7 @@ import { ComponentStoryFn, Meta } from '@storybook/react';
 
 import * as fake from '~/fixtures';
 
+import { Box } from './box';
 import { Button } from './button';
 import { Code } from './code';
 import { Drawer } from './drawer';
@@ -47,8 +48,9 @@ export const Overlay: ComponentStoryFn<any> = (args) => (
   <Drawer variant={args.variant}>
     <Drawer.Title>{args.title}</Drawer.Title>
     <Drawer.Description>{args.description}</Drawer.Description>
-
-    <Drawer.Body>Drawer content</Drawer.Body>
+    <Drawer.Body scroll="vertical">
+      <Box css={{ height: '200vh' }}>Drawer content - scrollable</Box>
+    </Drawer.Body>
   </Drawer>
 );
 

--- a/packages/react/src/components/drawer.tsx
+++ b/packages/react/src/components/drawer.tsx
@@ -48,8 +48,8 @@ type StyledDialogContentProps = ComponentProps<typeof StyledDialogContent>;
 
 const StyledDrawer = styled(Pane, {
   borderLeft: '1px solid $border-muted',
-  minHeight: '100%',
-  backgroundColor: '$bg-app-2',
+  height: '100%',
+  backgroundColor: '$bg-app',
   boxShadow: 'rgb(0 0 0 / 20%) 0px 4px 24px',
   variants: {
     width: {


### PR DESCRIPTION
The '`minHeight: 100%`' style on the drawer was preventing vertical scrolling for `variant="overlay"` drawers. Changing it to '`height: 100%`' sets the height of the drawer to the height of the viewport (since it's contained in a div that stretches to the height of its parent: which is` position:"fixed" `and 100% height).