### PR TITLE
feat: add state to button component

### DIFF
--- a/.changeset/lemon-owls-glow.md
+++ b/.changeset/lemon-owls-glow.md
@@ -1,0 +1,5 @@
+---
+'@darkmagic/react': patch
+---
+
+fix: default to button idle state

--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -274,7 +274,13 @@ const StyledLoader = styled('div', {
 function State({ state }: { state: 'idle' | 'loading' | 'error' | 'success' }) {
   return (
     <StyledLoader aria-hidden={true} data-state={state}>
-      {state === 'loading' ? <Spinner /> : state === 'success' ? <CheckIcon /> : <ExclamationTriangleIcon />}
+      {state === 'loading' ? (
+        <Spinner />
+      ) : state === 'success' ? (
+        <CheckIcon />
+      ) : state === 'error' ? (
+        <ExclamationTriangleIcon />
+      ) : null}
     </StyledLoader>
   );
 }


### PR DESCRIPTION
fix: default to button idle state
